### PR TITLE
chore: remove serverless-offline plugin from serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,8 @@ service: eureka-hello-api
 frameworkVersion: "3"
 
 plugins:
+  #WARN - failure in nodejs 22.x due to `serverless-offline` plugin @250627
+  # - serverless-offline
   - serverless-aws-documentation
   - serverless-prune-plugin
   - serverless-plugin-log-retention

--- a/serverless.yml
+++ b/serverless.yml
@@ -100,7 +100,7 @@ custom:
 #------------------------------------------------
 provider:
   name: aws
-  #NOTE - use the default profile.
+  #NOTE - use the default profile. (`none` 일때는 아래의 profile 설정이 없어야됨!)
   # profile: ${param:profile, 'none'}
   stage: ${opt:stage, 'dev'}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -98,6 +98,7 @@ custom:
 #------------------------------------------------
 provider:
   name: aws
+  #NOTE - use the default profile.
   # profile: ${param:profile, 'none'}
   stage: ${opt:stage, 'dev'}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,6 @@ service: eureka-hello-api
 frameworkVersion: "3"
 
 plugins:
-  - serverless-offline
   - serverless-aws-documentation
   - serverless-prune-plugin
   - serverless-plugin-log-retention


### PR DESCRIPTION
# upgrade to v4

## 문제 상황

* `node@18` 이상 환경(특히 `node@22`)에서 `serverless-offline` 플러그인 사용 시 다음과 같은 ESM 관련 오류가 발생했습니다:

  ```
  Error [ERR_REQUIRE_ASYNC_MODULE]: require() cannot be used on an ESM graph with top-level await.
  ```

* 이는 `serverless-offline` 플러그인이 ESM(`top-level await` 포함)으로 작성되어 있고, Serverless Framework에서 CommonJS 방식(`require()`)으로 로드하려 할 때 충돌이 발생하기 때문입니다.

## 개선 사항

* `serverless.yml`에서 해당 플러그인을 삭제했습니다.
